### PR TITLE
Remove PICO-8 Club entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Repositorio de enlaces de la comunidad
 - [Ogre Pixel](https://discord.gg/dJF56Xb)
 - [Score VG](https://discord.gg/PfGAXxA)
 - [Unity Indies Latam](https://discord.gg/BM6dgEc)
-- [PICO-8 Club](https://discord.gg/Ftjw2Cv)
 - [Mecha Studios](https://discord.gg/SjsF7ab)
 - [Game Devs MX](https://discord.gg/d5C83VkSWJ)
 - [Laboratorio de Juegos CCDMX](https://discord.gg/ZhmK9Zh)


### PR DESCRIPTION
Esta PR es para quitar el enlace de Discord de PICO-8 Club, pues ya no está activo y para evitarle futuras confusiones a gente nueva.

Además ya tenemos el foro en el Discord de Indi-es, donde se sigue discutiendo cosas de PICO-8.

![IMG_7768](https://github.com/indi-es/enlaces/assets/2427314/290c7650-73e3-45a7-9f0d-497bf03aba09)